### PR TITLE
Migrate from master/slave words

### DIFF
--- a/help/source/conf.py
+++ b/help/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'shpsync'

--- a/shp_excel_sync.py
+++ b/shp_excel_sync.py
@@ -141,7 +141,7 @@ class Syncer(QObject):
             if jinfo2 == jinfo:
                 info("Join already exists. Will not create it again")
                 return
-        info("Adding join between master and slave layers")
+        info("Adding join between main and subordinate layers")
         shpLayer.addJoin(jinfo)
 
     def reload_excel(self):

--- a/shpsync.py
+++ b/shpsync.py
@@ -214,10 +214,10 @@ class shpsync:
 
     def parseSettings(self):
         exps = self.dlg.getExpressionsDict()
-        excelName = self.dlg.comboBox_slave.currentText()
-        excelKeyName = self.dlg.comboBox_slave_key.currentText()
-        shpName = self.dlg.comboBox_master.currentText()
-        shpKeyName = self.dlg.comboBox_master_key.currentText()
+        excelName = self.dlg.comboBox_subordinate.currentText()
+        excelKeyName = self.dlg.comboBox_subordinate_key.currentText()
+        shpName = self.dlg.comboBox_main.currentText()
+        shpKeyName = self.dlg.comboBox_main_key.currentText()
         excelSheetName = self.dlg.lineEdit_sheetName.text()
         skipLines = self.dlg.spinBox.value()
         hideDialog = self.dlg.checkBox.isChecked()

--- a/shpsync_dialog.py
+++ b/shpsync_dialog.py
@@ -54,34 +54,34 @@ class shpsyncDialog(QtGui.QDialog, FORM_CLASS):
         self.dels = []
         self.combos = []
         self.hors = []
-        self.slave = None
-        self.master = None
-        self.populate(self.comboBox_master, isMaster=True)
-        self.populate(self.comboBox_slave, isMaster=False)
+        self.subordinate = None
+        self.main = None
+        self.populate(self.comboBox_main, isMain=True)
+        self.populate(self.comboBox_subordinate, isMain=False)
         self.pushButton.clicked.connect(self.addExpressionWidget)
 
     def restoreSettings(self, settings):
-        master_idx = self.comboBox_master.findText(settings.shpName)
-        slave_idx = self.comboBox_slave.findText(settings.excelName)
+        main_idx = self.comboBox_main.findText(settings.shpName)
+        subordinate_idx = self.comboBox_subordinate.findText(settings.excelName)
 
-        self.populate(self.comboBox_master, isMaster=True, idx=master_idx)
-        self.comboBox_master.setCurrentIndex(master_idx)
-        self.comboBox_master.setEnabled(False)
-        self.comboBox_master_key.setEnabled(False)
-        self.populate(self.comboBox_master, isMaster=True, idx=master_idx)
-        self.populate(self.comboBox_slave, isMaster=False, idx=slave_idx)
-        self.comboBox_slave.setCurrentIndex(slave_idx)
-        self.comboBox_slave.setEnabled(False)
-        self.comboBox_slave_key.setEnabled(False)
+        self.populate(self.comboBox_main, isMain=True, idx=main_idx)
+        self.comboBox_main.setCurrentIndex(main_idx)
+        self.comboBox_main.setEnabled(False)
+        self.comboBox_main_key.setEnabled(False)
+        self.populate(self.comboBox_main, isMain=True, idx=main_idx)
+        self.populate(self.comboBox_subordinate, isMain=False, idx=subordinate_idx)
+        self.comboBox_subordinate.setCurrentIndex(subordinate_idx)
+        self.comboBox_subordinate.setEnabled(False)
+        self.comboBox_subordinate_key.setEnabled(False)
         self.lineEdit_sheetName.setText(settings.excelSheetName)
         self.spinBox.setValue(settings.skipLines)
-        self.comboBox_slave_key.setCurrentIndex(self.comboBox_slave_key.findText(settings.excelKeyName))
-        self.comboBox_master_key.setCurrentIndex(self.comboBox_master_key.findText(settings.shpKeyName))
+        self.comboBox_subordinate_key.setCurrentIndex(self.comboBox_subordinate_key.findText(settings.excelKeyName))
+        self.comboBox_main_key.setCurrentIndex(self.comboBox_main_key.findText(settings.shpKeyName))
         self.checkBox.setCheckState(Qt.Checked if settings.hideDialog else Qt.Unchecked)
 
         for k, v in settings.expressions.iteritems():
             self.addExpressionWidget()
-            self.exps[-1].setLayer(self.master)
+            self.exps[-1].setLayer(self.main)
             self.exps[-1].setField(v)
             self.combos[-1].setCurrentIndex(self.combos[-1].findText(k))
 
@@ -98,10 +98,10 @@ class shpsyncDialog(QtGui.QDialog, FORM_CLASS):
         self.verticalLayout.addLayout(hor)
         self.exps.append(fieldExp)
         self.hors.append(hor)
-        if self.slave is not None:
-            self.updateComboBoxFromLayerAttributes(combo, self.slave.fields())
-        if self.master is not None:
-            fieldExp.setLayer(self.master)
+        if self.subordinate is not None:
+            self.updateComboBoxFromLayerAttributes(combo, self.subordinate.fields())
+        if self.main is not None:
+            fieldExp.setLayer(self.main)
         combo.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Preferred)
 
         del_btn.clicked.connect(self.removeExpressionWidget)
@@ -129,56 +129,56 @@ class shpsyncDialog(QtGui.QDialog, FORM_CLASS):
         del self.exps[idx]
         del self.hors[idx]
 
-    def populate(self, comboBox, isMaster, idx=0, update=True):
+    def populate(self, comboBox, isMain, idx=0, update=True):
         idlayers = list(QgsMapLayerRegistry.instance().mapLayers().iteritems())
-        self.populateFromLayers(comboBox, idlayers, isMaster)
+        self.populateFromLayers(comboBox, idlayers, isMain)
         if not idlayers:
             return
         if not update:
             return
-        if isMaster:
-            self.masterUpdated(idx)
+        if isMain:
+            self.mainUpdated(idx)
         else:
-            self.slaveUpdated(idx)
+            self.subordinateUpdated(idx)
 
-    def populateFromLayers(self, comboBox, idlayers, isMaster):
+    def populateFromLayers(self, comboBox, idlayers, isMain):
         comboBox.clear()
         for (id, layer) in idlayers:
             unicode_name = unicode(layer.name())
             comboBox.addItem(unicode_name, id)
 
-        if isMaster:
-            comboBox.currentIndexChanged.connect(self.masterUpdated)
+        if isMain:
+            comboBox.currentIndexChanged.connect(self.mainUpdated)
         else:
-            comboBox.currentIndexChanged.connect(self.slaveUpdated)
+            comboBox.currentIndexChanged.connect(self.subordinateUpdated)
 
     def updateComboBoxFromLayerAttributes(self, comboBox, attrs):
         comboBox.clear()
         for attr in attrs:
             comboBox.addItem(attr.name())
 
-    def masterUpdated(self, idx):
-        layer = qgis_utils.getLayerFromId(self.comboBox_master.itemData(idx))
+    def mainUpdated(self, idx):
+        layer = qgis_utils.getLayerFromId(self.comboBox_main.itemData(idx))
         if layer is None:
             return
-        self.master = layer
+        self.main = layer
         attributes = layer.fields()
         self.updateComboBoxFromLayerAttributes(
-            self.comboBox_master_key, attributes)
+            self.comboBox_main_key, attributes)
         # update layer in expressions
         for exp in self.exps:
             text = exp.currentText()
             exp.setLayer(layer)
             exp.setField(text)
 
-    def slaveUpdated(self, idx):
-        layer = qgis_utils.getLayerFromId(self.comboBox_slave.itemData(idx))
+    def subordinateUpdated(self, idx):
+        layer = qgis_utils.getLayerFromId(self.comboBox_subordinate.itemData(idx))
         if layer is None:
             return
-        self.slave = layer
+        self.subordinate = layer
         attributes = layer.fields()
         self.updateComboBoxFromLayerAttributes(
-            self.comboBox_slave_key, attributes)
+            self.comboBox_subordinate_key, attributes)
         # update sheet name suggestion
         try:
             wb = open_workbook(layer.publicSource())


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.